### PR TITLE
Update bodyParser

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -14,8 +14,9 @@ var routes     = globSync('./routes/*.js', { cwd: __dirname }).map(require);
 
 module.exports = function(emberCLIMiddleware) {
   var app = express();
-  app.use(bodyParser());
-
+  app.use(bodyParser.urlencoded({
+    extended: true
+  }));
   routes.forEach(function(route) { route(app); });
   app.use(emberCLIMiddleware);
 


### PR DESCRIPTION
bodyParser() has been deprecated, as of 6/19

Use: 

app.use(bodyParser.urlencoded())

or

app.use(bodyParser.json())

or

app.use(bodyParser.urlencoded({
  extended: true
}));

Depending on your needs
