### PR TITLE
Adds Bootstrap to Bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "emberreddit",
   "dependencies": {
+    "bootstrap": "~3.2.0",
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
     "qunit": "~1.12.0",


### PR DESCRIPTION
The lack of this was causing `app.import('vendor/bootstrap/dist/css/bootstrap.css');` in the Brocfile to 'splode on build or serve. :heart: :heart: :heart: 
